### PR TITLE
Update GitHub Actions tags to digests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
 
       steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Node setup
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 14.x
       - name: Dependencies
@@ -26,9 +26,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Node setup
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: 14.x
     - name: Dependencies


### PR DESCRIPTION
Digests are considered more secure, as it fixes the action to a specific commit

Check out [GitHubs documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
for more information on why this is important.

You already have dependabot enabled, all future updates will be pinned to digests :rocket:

I generated this change using [Frizbee](https://github.com/stacklok/frizbee),
an open source tool that flips tags to digests in Dockerfiles and GitHub Actions.

I created a second PR that add's the Frizbee action to the repository,
which will flip any future tags to digests automatically.
